### PR TITLE
Add support for TURN REST API

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -55,6 +55,8 @@ rtc:
   # stun_servers:
   #   - server1
   # # optional TURN servers for clients. This isn't necessary if using embedded TURN server (see below).
+  # # when the uri field is set, the server will user this uri to obtain a
+  # # dynamic TURN server configuration whenever a new user joins. If set other fields in the same list element will be ignored
   # turn_servers:
   #   - host: myhost.com
   #     port: 443
@@ -62,6 +64,7 @@ rtc:
   #     protocol: tls
   #     username: ""
   #     credential: ""
+  #     uri: ""
   # # allows LiveKit to monitor congestion when sending streams and automatically
   # # manage bandwidth utilization to avoid congestion/loss. Enabled by default
   # congestion_control:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -119,6 +119,7 @@ type TURNServer struct {
 	Protocol   string `yaml:"protocol,omitempty"`
 	Username   string `yaml:"username,omitempty"`
 	Credential string `yaml:"credential,omitempty"`
+	AuthURI    string `yaml:"uri,omitempty"`
 }
 
 type PLIThrottleConfig struct {

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -830,7 +830,7 @@ func (r *RoomManager) iceServersForParticipant(apiKey string, participant types.
 				err := temporaryAuthForTurn(s, is)
 				if err != nil {
 					logger.Errorw("Temporary auth request failed, falling back to config-read ", err)
-					configAuthRead(s, is)
+					continue
 				}
 			} else {
 				configAuthRead(s, is)
@@ -970,4 +970,5 @@ func configAuthRead(s config.TURNServer, is *livekit.ICEServer) {
 		Username:   s.Username,
 		Credential: s.Credential,
 	}
+
 }

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -16,7 +16,10 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"sync"
 	"time"
@@ -822,19 +825,15 @@ func (r *RoomManager) iceServersForParticipant(apiKey string, participant types.
 	if len(rtcConf.TURNServers) > 0 {
 		hasSTUN = true
 		for _, s := range r.config.RTC.TURNServers {
-			scheme := "turn"
-			transport := "tcp"
-			if s.Protocol == "tls" {
-				scheme = "turns"
-			} else if s.Protocol == "udp" {
-				transport = "udp"
-			}
-			is := &livekit.ICEServer{
-				Urls: []string{
-					fmt.Sprintf("%s:%s:%d?transport=%s", scheme, s.Host, s.Port, transport),
-				},
-				Username:   s.Username,
-				Credential: s.Credential,
+			is := &livekit.ICEServer{}
+			if s.AuthURI != "" {
+				err := temporaryAuthForTurn(s, is)
+				if err != nil {
+					logger.Errorw("Temporary auth request failed, falling back to config-read ", err)
+					configAuthRead(s, is)
+				}
+			} else {
+				configAuthRead(s, is)
 			}
 			iceServers = append(iceServers, is)
 		}
@@ -910,4 +909,65 @@ func iceServerForStunServers(servers []string) *livekit.ICEServer {
 		iceServer.Urls = append(iceServer.Urls, fmt.Sprintf("stun:%s", stunServer))
 	}
 	return iceServer
+}
+
+func temporaryAuthForTurn(s config.TURNServer, is *livekit.ICEServer) error {
+	req, err := http.NewRequest("GET", s.AuthURI, nil)
+	if err != nil {
+		logger.Errorw("could not create request", err)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		logger.Errorw("error making http request", err)
+	}
+
+	defer func(body io.ReadCloser) {
+		err := body.Close()
+		if err != nil {
+			logger.Errorw("could not close response reader", err)
+		}
+	}(res.Body)
+
+	body, readErr := io.ReadAll(res.Body)
+	if readErr != nil {
+		logger.Errorw("could not read response", readErr)
+	}
+
+	var response struct {
+		Username   string   `json:"username"`
+		Credential string   `json:"credential"`
+		TTL        int      `json:"ttl"`
+		URIs       []string `json:"uris"`
+	}
+
+	err = json.Unmarshal(body, &response)
+
+	is = &livekit.ICEServer{
+		Urls:       response.URIs,
+		Username:   response.Username,
+		Credential: response.Credential,
+	}
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func configAuthRead(s config.TURNServer, is *livekit.ICEServer) {
+	scheme := "turn"
+	transport := "tcp"
+	if s.Protocol == "tls" {
+		scheme = "turns"
+	} else if s.Protocol == "udp" {
+		transport = "udp"
+	}
+	is = &livekit.ICEServer{
+		Urls: []string{
+			fmt.Sprintf("%s:%s:%d?transport=%s", scheme, s.Host, s.Port, transport),
+		},
+		Username:   s.Username,
+		Credential: s.Credential,
+	}
 }


### PR DESCRIPTION
Hi,

[A REST API For Access To TURN Services](https://datatracker.ietf.org/doc/html/draft-uberti-behave-turn-rest-00) IETF Draft describes a standard REST API for obtaining access to TURN services. Supporting this could remove the need to specify static TURN servers and their credentials in the config file on startup. Also, it would enhance security for users since credentials would be generated per incoming users on the fly.  

This is a feature that LiveKit currently lacks. This PR aims to deliver this feature.

### Implementation details

A new field (`AuthURI string 'yaml:"uri,omitempty"'`) is added to the `TURNServer` [struct](https://github.com/livekit/livekit/blob/master/pkg/config/config.go#L116-L122) allowing the user to set the REST API's URI.   

Currently, when a new client joins a room, a list of ICE servers is created based on the configured list of TURN servers and it is sent back to the client. With this PR it is now possible to configure an Authentication URI in the LiveKit TURN server config. Then, the server will send an HTTP GET request to the configured URL and fetch the response to create the TURN server list. The response contains not only the TURN server URI but the username and credentials as well.

In case of a failure during fetching the configured API, the Authentication URI is ignored. This means there is no fallback to the other fields in that element of the list: once the AuthUri is configured other fields are ignored.

 Example:
 
 The following configuration is allowed, however, the `credential, host, port, protocol, username` fields are ignored.
 
 ```
       turn_servers:
        - credential: pass-1
          host: <turn-ip>
          port: 3478
          protocol: udp
          username: user-1
          uri: http://localhost:8088?service=turn
 ```
 
 If the user wants to set a static TURN server and a "dynamic one", they should configure the following way.
 
 ```
       turn_servers:
        - uri: http://localhost:8088?service=turn
        - credential: pass-1
          host: <turn-ip>
          port: 3478
          protocol: udp
          username: user-1
 ``` 


Initial code was adopted from @[Valniae](https://github.com/bbalint105). Kudos to him.